### PR TITLE
Removed redundant dependency plugin-assets-images

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,7 +20,6 @@
     "eslint-config-airbnb": "6.2.0",
     "eslint-plugin-react": "4.2.3",
     "roc-package-web-app-react-dev": "^1.0.0-alpha",
-    "roc-plugin-assets-images": "^1.0.0-alpha",
     "roc-plugin-style-sass": "^1.0.0-alpha"
   }
 }


### PR DESCRIPTION
We already have roc-plugin-assets-images available to us.
